### PR TITLE
chore: Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Amar Suhail <amar.suhail@gmail.com>",
   "maintainers": ["Ilya Shaisultanov <ilya.shaisultanov@gmail.com>"],
   "main": "./lib/prettystream.js",
+  "license": "MIT",
 
   "repository": {
     "type": "git",


### PR DESCRIPTION
We are using snyk and it cannot detect the license because it's not in the package.json